### PR TITLE
Update to singularity 3.0.2

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = singularity-container
 	pkgdesc = Container platform focused on supporting "Mobility of Compute".
-	pkgver = 3.0.0
+	pkgver = 3.0.2
 	pkgrel = 1
 	url = https://www.sylabs.io/singularity/
 	arch = i686
@@ -9,9 +9,9 @@ pkgbase = singularity-container
 	makedepends = go
 	makedepends = dep
 	depends = squashfs-tools
-	noextract = singularity-v3.0.0.tar.gz
-	source = https://github.com/sylabs/singularity/releases/download/v3.0.0/singularity-v3.0.0.tar.gz
-	md5sums = 019afc549c838ff08cabffe094c194b9
+	noextract = singularity-v3.0.2.tar.gz
+	source = https://github.com/sylabs/singularity/releases/download/v3.0.2/singularity-3.0.2.tar.gz
+	md5sums = 2f49faa5c6685b28e0124959d0e796a2
 
 pkgname = singularity-container
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,7 +22,7 @@ prepare() {
 build() {
   export GOPATH="${srcdir}/singularity"
   cd "${GOPATH}/src/github.com/sylabs/singularity"
-  ./mconfig -p /usr
+  ./mconfig --prefix="${pkgdir}/usr"
   cd builddir
   make
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Maciej Sieczka <msieczka at sieczka dot org>
 
 pkgname='singularity-container'
-pkgver='3.0.0'
+pkgver='3.0.2'
 pkgrel='1'
 pkgdesc='Container platform focused on supporting "Mobility of Compute".'
 arch=('i686' 'x86_64')
@@ -9,14 +9,14 @@ url='https://www.sylabs.io/singularity/'
 license=('BSD')
 makedepends=('go' 'dep')
 depends=('squashfs-tools')
-source=("https://github.com/sylabs/singularity/releases/download/v${pkgver}/singularity-v${pkgver}.tar.gz")
-noextract=("singularity-v${pkgver}.tar.gz")
-md5sums=('019afc549c838ff08cabffe094c194b9')
+source=("https://github.com/sylabs/singularity/releases/download/v${pkgver}/singularity-${pkgver}.tar.gz")
+noextract=("singularity-${pkgver}.tar.gz")
+md5sums=('2f49faa5c6685b28e0124959d0e796a2')
 
 prepare() {
   export GOPATH="${srcdir}/singularity"
   mkdir -p "${GOPATH}/src/github.com/sylabs"
-  tar -zxf singularity-v${pkgver}.tar.gz -C "${GOPATH}/src/github.com/sylabs"
+  tar -zxf singularity-${pkgver}.tar.gz -C "${GOPATH}/src/github.com/sylabs"
 }
 
 build() {


### PR DESCRIPTION
The name of the archive was changed to `singularity-$VERSION.tar.gz` from `singularity-v$VERSION.tar.gz` (see https://github.com/sylabs/singularity/releases/tag/v3.0.2).