### PR TITLE
Fix singularity version showing commit hash instead of package version.

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = singularity-container
 	pkgdesc = Container platform focused on supporting "Mobility of Compute".
 	pkgver = 3.5.3
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.sylabs.io/singularity/
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname='singularity-container'
 pkgver='3.5.3'
-pkgrel='1'
+pkgrel='2'
 pkgdesc='Container platform focused on supporting "Mobility of Compute".'
 arch=('i686' 'x86_64')
 url='https://www.sylabs.io/singularity/'
@@ -22,7 +22,7 @@ prepare() {
 build() {
   export GOPATH="${srcdir}/singularity"
   cd "${GOPATH}/src/github.com/sylabs/singularity"
-  ./mconfig --prefix=/usr --sysconfdir=/etc --localstatedir=/var --sbindir=/usr/bin
+  ./mconfig --prefix=/usr --sysconfdir=/etc --localstatedir=/var --sbindir=/usr/bin -V ${pkgver}
   cd builddir
   make
 }


### PR DESCRIPTION
Fixes #8 
Bumps pkgrel 1 -> 2

Before:
```
$ singularity version
bf6bdb5
```

After:
```
$ singularity version
3.5.3
```

singularity-compose checks if `version 3` is in the output of `singularity version` for example.