### PR TITLE
Install manual pages.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -30,6 +30,6 @@ build() {
 package() {
   export GOPATH="${srcdir}/singularity"
   cd "${GOPATH}/src/github.com/sylabs/singularity/builddir"
-  make DESTDIR="${pkgdir}" install
+  make DESTDIR="${pkgdir}" install man
 }
 


### PR DESCRIPTION
Currently the manual pages are not included. This PR installs manual pages by including the `man` make target in `package()`.

I did not include a pkgrel bump because this is so minor, but I would be happy to add one if desired.